### PR TITLE
Multiply

### DIFF
--- a/Math.Tests/TypesTests.fs
+++ b/Math.Tests/TypesTests.fs
@@ -1,85 +1,102 @@
-﻿namespace Freestylecoding.Math.Tests
+﻿namespace Freestylecoding.Math.Tests.Natural
 
 open Xunit
 open Freestylecoding.Math.Types
 
-module Types =
+module Addition =
     [<Theory>]
     [<InlineData( 1u, 1u, 2u )>]        // Sanity
+    [<InlineData( 1u, 0u, 1u )>]        // Sanity
+    [<InlineData( 0u, 1u, 1u )>]        // Sanity
     [<InlineData( 1u, 5u, 6u )>]        // l < r
     [<InlineData( 9u, 2u, 11u )>]       // l > r
-    let NaturalAddition l r s =
+    let Sanity l r s =
         let l = Natural ([l])
         let r = Natural ([r])
         Assert.Equal( Natural ([s]), l + r )
     
     [<Fact>]
-    let NaturalAdditionOverflow () =
+    let Overflow () =
         let l = Natural ([System.UInt32.MaxValue])
         let r = Natural ([3u])
         Assert.Equal( Natural ([1u; 2u]), l + r )
         
     [<Fact>]
-    let NaturalAdditionLeftBiggerNoOverflow () =
+    let LeftBiggerNoOverflow () =
         let l = Natural ([0xFu; 0xFu])
         let r = Natural ([0xFF00u])
         Assert.Equal( Natural ([0xFu; 0xFF0Fu]), l + r )
         
     [<Fact>]
-    let NaturalAdditionRightBiggerNoOverflow () =
+    let RightBiggerNoOverflow () =
         let l = Natural ([0xFF00u])
         let r = Natural ([0xFu; 0xFu])
         Assert.Equal( Natural ([0xFu; 0xFF0Fu]), l + r )
         
     [<Fact>]
-    let NaturalAdditionCascadingOverflow () =
+    let CascadingOverflow () =
         let l = Natural ([1u])
         let r = Natural ([System.UInt32.MaxValue; System.UInt32.MaxValue])
         Assert.Equal( Natural ([1u; 0u; 0u]), l + r )
 
     [<Fact>]
-    let NaturalAdditionOverflowCausedOverflow () =
+    let OverflowCausedOverflow () =
         let l = Natural ([1u; 1u])
         let r = Natural ([1u; System.UInt32.MaxValue - 1u; System.UInt32.MaxValue])
         Assert.Equal( Natural ([2u; 0u; 0u]), l + r )
 
+module LeftShift =
     [<Theory>]
-    [<InlineData( 1u, 1u, 2u )>]        // Sanity
-    [<InlineData( 0xFu, 2u, 0x3Cu )>]   // multiple bits
-    let NaturalLeftShift l r s =
+    [<InlineData( 1u, 1, 2u )>]        // Sanity
+    [<InlineData( 0xFu, 2, 0x3Cu )>]   // multiple bits
+    let Sanity l r s =
         Assert.Equal( Natural([s]), Natural([l]) <<< r )
         
     [<Fact>]
-    let NaturalLeftShiftOverflow () =
-        Assert.Equal( Natural([1u; 0xFFFFFFFEu]), Natural([0xFFFFFFFFu]) <<< 1u )
+    let Overflow () =
+        Assert.Equal( Natural([1u; 0xFFFFFFFEu]), Natural([0xFFFFFFFFu]) <<< 1 )
         
     [<Fact>]
-    let NaturalLeftShiftMultipleOverflow () =
-        Assert.Equal( Natural([0x5u; 0xFFFFFFF8u]), Natural([0xBFFFFFFFu]) <<< 3u )
+    let MultipleOverflow () =
+        Assert.Equal( Natural([0x5u; 0xFFFFFFF8u]), Natural([0xBFFFFFFFu]) <<< 3 )
         
     [<Fact>]
-    let NaturalLeftShiftOverOneUInt () =
-        Assert.Equal( Natural([8u; 0u; 0u]), Natural([1u]) <<< 67u )
+    let OverOneUInt () =
+        Assert.Equal( Natural([8u; 0u; 0u]), Natural([1u]) <<< 67 )
 
+module RightShift =
     [<Theory>]
-    [<InlineData( 1u, 1u, 0u )>]        // Sanity
-    [<InlineData( 0xFu, 2u, 0x3u )>]    // multiple bits
-    [<InlineData( 0x3Cu, 2u, 0xFu )>]    // multiple bits
-    let NaturalRightShift l r s =
+    [<InlineData( 1u, 1, 0u )>]        // Sanity
+    [<InlineData( 0xFu, 2, 0x3u )>]    // multiple bits
+    [<InlineData( 0x3Cu, 2, 0xFu )>]   // multiple bits
+    let Sanity l r s =
         Assert.Equal( Natural([s]), Natural([l]) >>> r )
+
+    [<Fact>]
+    let Underflow () =
+        Assert.Equal( Natural([0x7FFFFFFFu]), Natural([0xFFFFFFFFu]) >>> 1 )
         
     [<Fact>]
-    let NaturalRightShiftUnderflow () =
-        Assert.Equal( Natural([0x7FFFFFFFu]), Natural([0xFFFFFFFFu]) >>> 1u )
+    let MultipleUnderflow () =
+        Assert.Equal( Natural([0x1u; 0x5FFFFFFFu]), Natural([0xAu; 0xFFFFFFFFu]) >>> 3 )
         
     [<Fact>]
-    let NaturalRightShiftMultipleUnderflow () =
-        Assert.Equal( Natural([0x1u; 0x5FFFFFFFu]), Natural([0xAu; 0xFFFFFFFFu]) >>> 3u )
+    let OverOneUInt () =
+        Assert.Equal( Natural([1u]), Natural([0x10u; 0u; 0u]) >>> 68 )
         
     [<Fact>]
-    let NaturalRightShiftOverOneUInt () =
-        Assert.Equal( Natural([1u]), Natural([0x10u; 0u; 0u]) >>> 68u )
-        
+    let ReduceToZero () =
+        Assert.Equal( Natural([0u]), Natural([0x10u; 0u; 0u]) >>> 99 )
+
+module Multiply =
+    [<Theory>]
+    [<InlineData( 1u, 1u, 1u )>]        // Sanity
+    [<InlineData( 1u, 0u, 0u )>]        // Sanity
+    [<InlineData( 0u, 1u, 0u )>]        // Sanity
+    [<InlineData( 6u, 7u, 42u )>]       // multiple bits
+    let Sanity l r p =
+        Assert.Equal( Natural([p]), Natural([l]) * Natural([r]) )
+
     [<Fact>]
-    let NaturalRightShiftReduceToZero () =
-        Assert.Equal( Natural([0u]), Natural([0x10u; 0u; 0u]) >>> 99u )
+    let Big () =
+        Assert.Equal( Natural([ 0x75CD9046u; 0x541D5980u]), Natural( [0xFEDCBA98u]) * Natural([0x76543210u]) )

--- a/Math/Types.fs
+++ b/Math/Types.fs
@@ -4,6 +4,73 @@ open System
 
 module Types = 
     type public Natural = Natural of uint32 list
+        with
+            static member Zero
+                with get() = [0u]
+
+            static member (+) ((Natural left), (Natural right)) : Natural =
+                let rightpad (l:uint32 list) n =
+                    List.init (n - l.Length) (fun i -> 0u) @ l
+
+                let leftpad l n =
+                    l @ List.init (n - l.Length) (fun i -> 0u)
+
+                let len = Math.Max( left.Length, right.Length )
+                let l = rightpad left len
+                let r = rightpad right len
+                let s = rightpad (List.map2 (fun x y -> x + y) l r) (len+1)
+                let o = leftpad (List.map2 (fun  x y -> if x >= ( System.UInt32.MaxValue - y ) then 1u else 0u) l r) (len+1)
+                let n = List.map2 (fun x y -> x + y ) s o
+
+                Natural( if 0u = n.Head then n.Tail else n )
+
+            static member (<<<) ((Natural left), (right:uint32)) : Natural =
+                let msb = 0x80000000u
+
+                let shift1 (l:uint32 list) =
+                    let s = 0u :: (List.map (fun x -> x <<< 1) l)
+                    let o = (List.map (fun x -> if (msb &&& x) > 0u then 1u else 0u) l) @ [0u]
+                    let n = List.map2 (fun x y -> x ||| y) s o
+                    if 0u = n.Head then n.Tail else n
+
+                let rec shift (l:uint32 list) n =
+                    match n with
+                    | 0u -> l
+                    | x -> shift1 (shift l (n-1u))
+
+                let rDiv = right / 32u
+                let rMod = right % 32u
+
+                let l = left @ (List.init (int(rDiv)) (fun i -> 0u))
+                Natural( shift l rMod )
+
+            static member (>>>) ((Natural left), (right:uint32)) : Natural =
+                let msb = 0x80000000u
+
+                let rec chomp l n =
+                    match l with
+                    | [] -> [0u]
+                    | _ ->
+                        match n with
+                        | 0u -> l
+                        | x -> chomp (List.rev l |> List.tail |> List.rev) (n-1u)
+
+                let shift1 (l:uint32 list) =
+                    let s = (List.map (fun x -> x >>> 1) l) @ [0u]
+                    let o = 0u :: (List.map (fun x -> if (1u &&& x) > 0u then msb else 0u) l)
+                    let n = List.map2 (fun x y -> x ||| y) s o
+                    chomp (if 0u = n.Head then n.Tail else n) 1u
+
+                let rec shift (l:uint32 list) n =
+                    match n with
+                    | 0u -> l
+                    | x -> shift1 (shift l (n-1u))
+
+                let rDiv = right / 32u
+                let rMod = right % 32u
+
+                let l = chomp left rDiv
+                Natural( shift l rMod )
 
     let inline private value (Natural n) = n
 
@@ -12,70 +79,6 @@ module Types =
         let x = i - ((i >>> 1) &&& 0x55555555u);
         let y = (x &&& 0x33333333u) + ((x >>> 2) &&& 0x33333333u);
         (((y + (y >>> 4)) &&& 0x0F0F0F0Fu) * 0x01010101u) >>> 24;
-
-    let (+) (Natural left) (Natural right) : Natural =
-        let rightpad (l:uint32 list) n =
-            List.init (n - l.Length) (fun i -> 0u) @ l
-
-        let leftpad l n =
-            l @ List.init (n - l.Length) (fun i -> 0u)
-
-        let len = Math.Max( left.Length, right.Length )
-        let l = rightpad left len
-        let r = rightpad right len
-        let s = rightpad (List.map2 (fun x y -> x + y) l r) (len+1)
-        let o = leftpad (List.map2 (fun  x y -> if x >= ( System.UInt32.MaxValue - y ) then 1u else 0u) l r) (len+1)
-        let n = List.map2 (fun x y -> x + y ) s o
-
-        Natural( if 0u = n.Head then n.Tail else n )
-        
-    let (<<<) (Natural left) (right:uint32) : Natural =
-        let msb = 0x80000000u
-
-        let shift1 (l:uint32 list) =
-            let s = 0u :: (List.map (fun x -> x <<< 1) l)
-            let o = (List.map (fun x -> if (msb &&& x) > 0u then 1u else 0u) l) @ [0u]
-            let n = List.map2 (fun x y -> x ||| y) s o
-            if 0u = n.Head then n.Tail else n
-
-        let rec shift (l:uint32 list) n =
-            match n with
-            | 0u -> l
-            | x -> shift1 (shift l (n-1u))
-
-        let rDiv = right / 32u
-        let rMod = right % 32u
-
-        let l = left @ (List.init (int(rDiv)) (fun i -> 0u))
-        Natural( shift l rMod )
-
-    let (>>>) (Natural left) (right:uint32) : Natural =
-        let msb = 0x80000000u
-
-        let rec chomp l n =
-            match l with
-            | [] -> [0u]
-            | _ ->
-                match n with
-                | 0u -> l
-                | x -> chomp (List.rev l |> List.tail |> List.rev) (n-1u)
-
-        let shift1 (l:uint32 list) =
-            let s = (List.map (fun x -> x >>> 1) l) @ [0u]
-            let o = 0u :: (List.map (fun x -> if (1u &&& x) > 0u then msb else 0u) l)
-            let n = List.map2 (fun x y -> x ||| y) s o
-            chomp (if 0u = n.Head then n.Tail else n) 1u
-
-        let rec shift (l:uint32 list) n =
-            match n with
-            | 0u -> l
-            | x -> shift1 (shift l (n-1u))
-
-        let rDiv = right / 32u
-        let rMod = right % 32u
-
-        let l = chomp left rDiv
-        Natural( shift l rMod )
 
     let (*) (Natural left) (Natural right) : Natural =
         let leftbitcount = 
@@ -86,7 +89,17 @@ module Types =
             List.map NumberOfSetBits right
             |> List.sum
 
-        let l = if leftbitcount > rightbitcount then left else right
-        let r = if leftbitcount > rightbitcount then right else left
+        let l = Natural(if leftbitcount > rightbitcount then left else right)
+        let r = (if leftbitcount > rightbitcount then right else left) |> List.rev
 
-        Natural([])
+        let rec f (i:int) (b:int) (x:uint32) : Natural list =
+            match x >>> b with
+            | 0u -> []
+            | n ->
+                match n &&& 1u with
+                | 0u -> f i (b+1) x
+                | 1u -> (l <<< (uint32 ((i * 32) + b))) :: (f i (b+1) x)
+
+        List.mapi (fun i x -> f i 0 x) r
+        |> List.concat
+        |> List.sum

--- a/Math/Types.fs
+++ b/Math/Types.fs
@@ -78,4 +78,15 @@ module Types =
         Natural( shift l rMod )
 
     let (*) (Natural left) (Natural right) : Natural =
+        let leftbitcount = 
+            List.map NumberOfSetBits left
+            |> List.sum
+
+        let rightbitcount = 
+            List.map NumberOfSetBits right
+            |> List.sum
+
+        let l = if leftbitcount > rightbitcount then left else right
+        let r = if leftbitcount > rightbitcount then right else left
+
         Natural([])


### PR DESCRIPTION
Mostly created Multiply

However, I also discovered that F# didn't like how I was overloading my other operators. Namely, the right side of `<<<` and `>>>` had to be int.  I fixed that.

Did some digging in the F# spec, and it appears shift with a negative number is undefined. As such, I ignored the fact that someone could put in a negative now.